### PR TITLE
UI features - Included the function onMobileToggleClick() in the as part of the props in RosterHeaderProps interface since it was being used inline 64 of the file src/components/ui/Roster/Roster.header.tsx and had not been included as part of the props in the interface RosterHeaderProps in the file src/components/ui/Roster/RosterHeader.tsx within the

### DIFF
--- a/src/components/ui/Roster/RosterHeader.tsx
+++ b/src/components/ui/Roster/RosterHeader.tsx
@@ -34,7 +34,7 @@ export interface RosterHeaderProps
   onSearch?: (e: ChangeEvent<HTMLInputElement>) => void;
   /** The callback fired when roster is closed. */
   onClose?: () => void;
-  /** The callback fired when the modile toggler is clicked*/
+  /** The callback fired when the mobile toggler is clicked*/
   onMobileToggleClick?: () => void;
   /** The PopOver menu for more options. */
   menu?: React.ReactNode;

--- a/src/components/ui/Roster/RosterHeader.tsx
+++ b/src/components/ui/Roster/RosterHeader.tsx
@@ -34,6 +34,8 @@ export interface RosterHeaderProps
   onSearch?: (e: ChangeEvent<HTMLInputElement>) => void;
   /** The callback fired when roster is closed. */
   onClose?: () => void;
+  /** The callback fired when the modile toggler is clicked*/
+  onMobileToggleClick?: () => void;
   /** The PopOver menu for more options. */
   menu?: React.ReactNode;
   /** The label for availability. */
@@ -89,6 +91,7 @@ export const RosterHeader: React.FC<RosterHeaderProps> = ({
   searchValue,
   onClose,
   onSearch,
+  onMobileToggleClick,
   className,
   menu,
   a11yMenuLabel = '',


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**


**Testing**
1. Have you successfully run `npm run build:release` locally?

2. How did you test these changes?

3. If you made changes to the component library, have you provided corresponding documentation changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
